### PR TITLE
Fix import path to "nodegit" from relative import

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ source](http://www.nodegit.org/guides/install/from-source/) instructions.
 ### Cloning a repository and reading a file: ###
 
 ``` javascript
-var clone = require("./").Clone.clone;
+var clone = require("nodegit").Clone.clone;
 
 // Clone a given repository into a specific folder.
 clone("https://github.com/nodegit/nodegit", "tmp", null)


### PR DESCRIPTION
The example is linking to a relative path, not to the `nodegit` package like the other examples.
